### PR TITLE
Fix trailing comma in a function's list of parameters/attributes that causes a fatal server error for sites on PHP 7.2

### DIFF
--- a/class/Controller/AdminNoticesController.php
+++ b/class/Controller/AdminNoticesController.php
@@ -222,7 +222,7 @@ class AdminNoticesController extends \ShortPixel\Controller
 						'<a href="' . $link2 . '" target="_blank">', '</a>',
 						'</p>', '<p>',
  						'<a href="' . $link3 . '" >', '</a>',
-						'</p>',
+						'</p>'
 					);
 					$notice = Notices::addNormal($message);
 					Notices::makePersistent($notice, self::MSG_FEATURE_SMARTCROP, YEAR_IN_SECONDS);


### PR DESCRIPTION
This coincides with the issue detailed at https://wordpress.org/support/topic/version-5-1-causes-site-wide-fatal-server-error-on-php-7-2/#post-16120051 and the GH issue at https://github.com/short-pixel-optimizer/shortpixel-image-optimiser/issues/110