### PR TITLE
Fix for getty images plugin conflict

### DIFF
--- a/res/js/screens/screen-media.js
+++ b/res/js/screens/screen-media.js
@@ -95,7 +95,7 @@ class ShortPixelScreen extends ShortPixelScreenItemBase //= function (MainScreen
             render: function()
             {
                detailsColumn.prototype.render.apply( this );
-               this.fetchSPIOData(this.model.get( 'id' ));
+               if(typeof this.fetchSPIOData === 'function') this.fetchSPIOData(this.model.get( 'id' ));
 
                return this;
             },


### PR DESCRIPTION
For some reason this one line causes an error in the Getty Images Plugin, it's probably due to a poorly written Getty Images plugin but it was easier to fix here.

To replicate, install the [Getty Images plugin](https://wordpress.org/plugins/getty-images/), insert a Getty image block, and browse for an image. Without ShortPixel enabled it works fine. With ShortPixel enabled you get an error saying this.fetchSPIOData is not a function and it won't let you insert the image.