### PR TITLE
Fix deprecated case statement syntax (semicolon to colon).

### DIFF
--- a/class/Controller/AjaxController.php
+++ b/class/Controller/AjaxController.php
@@ -331,7 +331,7 @@ class AjaxController
 				$this->checkActionAccess($action, 'is_editor');
 				$json = $this->scanNextFolder($json, $data);
 				break;
-			case 'resetScanFolderChecked';
+			case 'resetScanFolderChecked':
 				$this->checkActionAccess($action, 'is_editor');
 				$json = $this->resetScanFolderChecked($json, $data);
 				break;

--- a/class/Controller/View/BulkViewController.php
+++ b/class/Controller/View/BulkViewController.php
@@ -114,7 +114,7 @@ class BulkViewController extends \ShortPixel\ViewController
   {
       switch($operation)
       {
-          case 'bulk-restore';
+          case 'bulk-restore':
             $label = __('Bulk Restore', 'shortpixel-image-optimiser');
           break;
           case 'migrate':

--- a/class/Model/AdminNoticeModel.php
+++ b/class/Model/AdminNoticeModel.php
@@ -117,7 +117,7 @@ abstract class AdminNoticeModel
        case 'error':
         $notice = Notices::addError($this->getMessage());
        break;
-			 case 'normal';
+			 case 'normal':
 			 default:
 			 	$notice = Notices::addNormal($this->getMessage());
 

--- a/shortpixel-plugin.php
+++ b/shortpixel-plugin.php
@@ -720,7 +720,7 @@ class ShortPixelPlugin {
 					case 'upload':
                   $controller = '\ShortPixel\Controller\View\ListMediaViewController';
                         break;
-					case 'attachment'; // edit-media
+					case 'attachment': // edit-media
                    $controller = '\ShortPixel\Controller\View\EditMediaViewController';
                      break;
                 }


### PR DESCRIPTION
Fixes "E_DEPRECATED: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead" warnings.