### PR TITLE
Fix: Prevent fatal crash when ShortPixel cannot download a file

### DIFF
--- a/class/Helper/DownloadHelper.php
+++ b/class/Helper/DownloadHelper.php
@@ -87,6 +87,9 @@ class DownloadHelper
 
 				$args = wp_parse_args($args, $defaults);
         $success = false;
+        $result = false;
+        $tempFile = null;
+        $this->last_download_error = null;
 
 				Log::addDebug('Downloading file :' . $url, $args);
 
@@ -115,7 +118,15 @@ class DownloadHelper
 					if (false === $success)
 					{
 						Log::addError('Failed to download File', $result);
-            $this->last_download_error = $tempFile->get_error_message();
+
+            if (is_wp_error($result))
+            {
+                $this->last_download_error = $result->get_error_message();
+            }
+            elseif (empty($this->last_download_error))
+            {
+                $this->last_download_error = __('File download failed.', 'shortpixel-image-optimiser');
+            }
 						//ResponseController::addData('is_error', true);
 						//Responsecontroller::addData('message', $tempFile->get_error_message());
 						return false;


### PR DESCRIPTION
\## Summary



This PR fixes a fatal error in `DownloadHelper::downloadFile()` when all download methods fail.



Issue: #186

