### PR TITLE
Fix image block corruption when AI returns integer status codes

### DIFF
--- a/res/js/screens/screen-media.js
+++ b/res/js/screens/screen-media.js
@@ -1064,6 +1064,25 @@ class ShortPixelScreen extends ShortPixelScreenItemBase //= function (MainScreen
 			return false;
 		}
 
+		// Fields disabled in settings, or skipped by 'preserve existing', come back as
+		// integer status codes instead of text. Only apply real core/image attributes
+		// holding a string: an integer caption makes the block's save() throw, after
+		// which Gutenberg serializes the image block as an empty void comment.
+		var attributes = {};
+
+		if (typeof aiData !== 'undefined') {
+			if (typeof aiData.alt === 'string') {
+				attributes.alt = aiData.alt;
+			}
+			if (typeof aiData.caption === 'string') {
+				attributes.caption = aiData.caption;
+			}
+		}
+
+		if (Object.keys(attributes).length === 0) {
+			return false;
+		}
+
 		let blocks = wp.data.select('core/block-editor').getBlocks();
 		for (let i = 0; i < blocks.length; i++) {
 			let block = blocks[i];
@@ -1072,7 +1091,7 @@ class ShortPixelScreen extends ShortPixelScreenItemBase //= function (MainScreen
 				let clientId = block.clientId;
 
 				wp.data.dispatch('core/block-editor').updateBlockAttributes(clientId,
-					aiData);
+					attributes);
 
 			}
 		}


### PR DESCRIPTION
Fields disabled in settings, or skipped by "preserve existing SEO data", arrive as integer status codes rather than strings. UpdateGutenBerg() passed the whole aiData object to updateBlockAttributes(), so core/image received a numeric caption. That makes the block's save() throw, and Gutenberg then serializes the image as an empty void comment, losing the image markup.

Apply only core/image attributes holding a string, mirroring the existing guard in FetchAltView(). Also drops the stray description and post_title keys, which are not core/image attributes.